### PR TITLE
Sanity check vnc password length

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,9 @@
 #yum_proxy: "http://10.1.1.4:3128"
 #
 # A VNC server is running on the system being kickstarted so one can
-# troubleshoot problems. If "vnc_password" is set, this is used as the
-# password needed when connecting to the VNC server, otherwise no
-# password is needed.
+# troubleshoot problems. If "vnc_password" is set and is between 6 and
+# 8 characters long, this is used as the password needed when
+# connecting to the VNC server, otherwise no password is needed.
 
 # ansible-pull at the end of the kickstart is disabled by default, set it to true in the group_vars
 ansible_pull_kickstart: false

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -2,7 +2,7 @@
 text
 skipx
 cmdline
-{% if vnc_password is defined %}
+{% if vnc_password is defined and (vnc_password|length >= 6 and vnc_password|length <= 8) %}
 vnc --password={{ vnc_password }}
 {% else %}
 vnc


### PR DESCRIPTION
Kickstart croaks if the length of the vnc password is not between 6 and 8 characters.
