### PR TITLE
Optionally set up serial console in kickstart

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,6 @@ kickstart_packages: |
 
 kickstart_extra_post_commands: |
  "echo no extra kickstart post commands defined"
+
+# Should kickstart set up the serial console
+serial_console_enable: false

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -116,5 +116,31 @@ fi
 {{ kickstart_extra_post_commands }}
 {% endif %}
 
+{% if serial_console_enable %}
+# Remove " rhgb quiet"
+perl -pi -e 's/(.*) rhgb quiet(.*)/$1$2/g' /etc/default/grub
+
+# Set GRUB_TERMINAL="console serial"
+perl -pi -e 's/GRUB_TERMINAL(.*)/GRUB_TERMINAL="console serial"/g' /etc/default/grub
+
+# Add serial stuff to GRUB_CMDLINE_LINUX
+grep console=ttyS0 /etc/default/grub >/dev/null
+if [ $? -ne 0 ];then
+    perl -pi -e 's/GRUB_CMDLINE_LINUX=(.*)"/GRUB_CMDLINE_LINUX=$1 console=tty0 console=ttyS0,115200"/g' /etc/default/grub
+fi
+
+# Add GRUB_SERIAL_COMMAND
+grep GRUB_SERIAL_COMMAND /etc/default/grub >/dev/null
+if [ $? -ne 0 ];then
+    echo 'GRUB_SERIAL_COMMAND="serial --speed=115200"' >> /etc/default/grub
+fi
+
+if [ -d /sys/firmware/efi ];then
+    /usr/sbin/grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg
+else
+    /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+fi
+{% endif %}
+
 %end
 #


### PR DESCRIPTION
Setting up the serial console in ansible-role-serial-console is not sufficient, as then it's run only after rebooting the node and ansible-pull is run. Then the node needs to be rebooted again for the changes to be activated. By setting it up directly in kickstart we can avoid that.
