### PR TITLE
Create initial /etc/hosts from template

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -38,7 +38,7 @@
   lineinfile: 
         dest='{{ hosts_file_to_populate }}'
         regexp='^{{ hostvars[item].int_ip_addr }} {{ siteName }}-admin {{item}} {{ siteName }}-admin.{{ intDomain }}.{{ siteDomain }}$' 
-        line="{{ hostvars[item].int_ip_addr }} {{ siteName }}-admin {{item}} {{ siteName }}-admin.{{ intDomain }}.{{ siteDomain }}" 
+        line="{{ hostvars[item].int_ip_addr }} {{ siteName }}-admin {{item}} {{ siteName }}-admin.{{ intDomain }}.{{ siteDomain }} {{ item }}.{{ intDomain }}.{{ siteDomain }}"
         state=present
   when: hostvars[item].int_ip_addr is defined and hosts_file_admin_group_to_populate != ""
   with_items: "{{ hosts_file_admin_group_to_populate }}"
@@ -50,7 +50,7 @@
   lineinfile: 
         dest='{{ hosts_file_to_populate }}'
         regexp='^{{ hostvars[item].int_ip_addr }} {{ siteName }}-grid {{item}} {{ siteName }}-grid.{{ intDomain }}.{{ siteDomain }}$' 
-        line="{{ hostvars[item].int_ip_addr }} {{ siteName }}-grid {{item}} {{ siteName }}-grid.{{ intDomain }}.{{ siteDomain }}" 
+        line="{{ hostvars[item].int_ip_addr }} {{ siteName }}-grid {{item}} {{ siteName }}-grid.{{ intDomain }}.{{ siteDomain }} {{ item }}.{{ intDomain }}.{{ siteDomain }}"
         state=present
   when: hostvars[item].int_ip_addr is defined and hosts_file_grid_group_to_populate != ""
   with_items: "{{ hosts_file_grid_group_to_populate }}"
@@ -62,7 +62,7 @@
   lineinfile: 
         dest='{{ hosts_file_to_populate }}'
         regexp='^{{ hostvars[item].int_ip_addr }} {{ siteName }}-install {{item}} {{ siteName }}-install.{{ intDomain }}.{{ siteDomain }}$' 
-        line="{{ hostvars[item].int_ip_addr }} {{ siteName }}-install {{item}} {{ siteName }}-install.{{ intDomain }}.{{ siteDomain }}" 
+        line="{{ hostvars[item].int_ip_addr }} {{ siteName }}-install {{item}} {{ siteName }}-install.{{ intDomain }}.{{ siteDomain }} {{ item }}.{{ intDomain }}.{{ siteDomain }}"
         state=present
   when: hostvars[item].int_ip_addr is defined and hosts_file_install_group_to_populate != ""
   with_items: "{{ hosts_file_install_group_to_populate }}"
@@ -74,7 +74,7 @@
   lineinfile: 
         dest='{{ hosts_file_to_populate }}'
         regexp='^{{ hostvars[item].int_ip_addr }} {{ siteName }} {{item}} {{ siteName }}.{{ intDomain }}.{{ siteDomain }}$' 
-        line="{{ hostvars[item].int_ip_addr }} {{ siteName }} {{item}} {{ siteName }}.{{ intDomain }}.{{ siteDomain }}" 
+        line="{{ hostvars[item].int_ip_addr }} {{ siteName }} {{item}} {{ siteName }}.{{ intDomain }}.{{ siteDomain }} {{ item }}.{{ intDomain }}.{{ siteDomain }}"
         state=present
   when: hostvars[item].int_ip_addr is defined and hosts_file_login_group_to_populate != ""
   with_items: "{{ hosts_file_login_group_to_populate }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -28,26 +28,8 @@
   template: src=pxe_node.conf dest="/var/www/provision/nodes/{{ hostvars[item].pxe_name }}.conf"
   with_items: "{{ groups.pxe_bootable_nodes }}"
 
-- name: populate hosts file with PXE hosts
-  lineinfile: 
-        dest='{{ hosts_file_to_populate }}'
-        regexp='^{{ hostvars[item].int_ip_addr }} {{ hostvars[item].pxe_name }} {{ hostvars[item].pxe_name }}.{{ intDomain }}.{{ siteDomain }}$' 
-        line="{{ hostvars[item].int_ip_addr }} {{ hostvars[item].pxe_name }} {{ hostvars[item].pxe_name }}.{{ intDomain }}.{{ siteDomain }}" 
-        state=present
-  when: hostvars[item].int_ip_addr is defined
-  with_items: "{{ groups.pxe_bootable_nodes }}"
-  notify:
-    - restart dnsmasq
-  tags: dns_update
-
-- name: populate hosts file with PXE hosts-ib IP addresses
-  lineinfile: 
-        dest='{{ hosts_file_to_populate }}'
-        regexp='^{{ hostvars[item].ib_ip_addr }} {{ hostvars[item].pxe_name }}-ib {{ hostvars[item].pxe_name }}-ib.{{ intDomain }}.{{ siteDomain }}$' 
-        line="{{ hostvars[item].ib_ip_addr }} {{ hostvars[item].pxe_name }}-ib {{ hostvars[item].pxe_name }}-ib.{{ intDomain }}.{{ siteDomain }}" 
-        state=present
-  when: hostvars[item].ib_ip_addr is defined and hosts_file_pxe_group_to_populate != ""
-  with_items: "{{ hosts_file_pxe_group_to_populate }}"
+- name: populate hosts file from template with PXE hosts
+  template: src='hosts.j2' dest='{{ hosts_file_to_populate }}' owner=root group=root mode='0644'
   notify:
     - restart dnsmasq
   tags: dns_update

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,0 +1,10 @@
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+{% for item in hosts_file_pxe_group_to_populate %}
+{{ hostvars[item].int_ip_addr }} {{ hostvars[item].pxe_name }} {{ hostvars[item].pxe_name }}.{{ intDomain }}.{{ siteDomain }}
+{% if hostvars[item].ib_ip_addr is defined %}
+{{ hostvars[item].ib_ip_addr }} {{ hostvars[item].pxe_name }}-ib {{ hostvars[item].pxe_name }}-ib.{{ intDomain }}.{{ siteDomain }}
+{% endif %}
+{% endfor %}
+


### PR DESCRIPTION
This patch reduces the time for

ansible-playbook install.yml --tags=pxe

from roughly 11m to 6m. As a side-effect, /etc/hosts on the install node is always recreated. It might be good, as it will clean out old cruft (e.g. if nodes have been renamed) but might also cause issues, so something to watch out for.

Related to https://github.com/CSC-IT-Center-for-Science/ansible-role-pxe_config/issues/14
