### PR TITLE
Create pxe_nodes.json with all PXE node profiles

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -24,6 +24,9 @@
 - name: create_pxe_directory_structure
   file: path=/var/www/provision/nodes state=directory owner=apache group=apache mode="0755"
 
+- name: create pxe boot data json file
+  template: src='pxe_nodes.json.j2' dest='/var/www/provision/nodes/pxe_nodes.json'
+
 - name: create_pxe_boot_data
   template: src=pxe_node.conf dest="/var/www/provision/nodes/{{ hostvars[item].pxe_name }}.conf"
   with_items: "{{ groups.pxe_bootable_nodes }}"

--- a/templates/pxe_nodes.json.j2
+++ b/templates/pxe_nodes.json.j2
@@ -1,0 +1,10 @@
+{
+{% for item in hosts_file_pxe_group_to_populate %}
+  "{{ item }}": {
+    "kickstart_profile": "{{ hostvars[item]['kickstart_profile'] }}",
+    "kickstart_server_ip": "{{ hostvars[item]['kickstart_server_ip'] }}"
+  }{% if not loop.last %},
+{% endif %}
+{% endfor %}
+
+}


### PR DESCRIPTION
This is step 1 of making the creation of the PXE node profiles
faster. Step 2 is to modify ansible-role-pxe_bootstrap/files/boot.py
to retrieve the node information from this JSON file, step 3 is to
remove the creation of the per-node files.
