### PR TITLE
Remove the creation of individual pxe node conf files

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -24,10 +24,6 @@
 - name: create_pxe_directory_structure
   file: path=/var/www/provision/nodes state=directory owner=apache group=apache mode="0755"
 
-- name: create_pxe_boot_data
-  template: src=pxe_node.conf dest="/var/www/provision/nodes/{{ hostvars[item].pxe_name }}.conf"
-  with_items: "{{ groups.pxe_bootable_nodes }}"
-
 - name: populate hosts file from template with PXE hosts
   template: src='hosts.j2' dest='{{ hosts_file_to_populate }}' owner=root group=root mode='0644'
   notify:


### PR DESCRIPTION
This is the final step 3 making the ansible task "create pxe boot
data" faster. It depends on the previous 2 steps. In step 1
(https://github.com/CSC-IT-Center-for-Science/ansible-role-pxe_config/pull/17),
pxe_nodes.json containing the PXE boot data for all nodes was
created. In step 2
(https://github.com/CSC-IT-Center-for-Science/ansible-role-pxe_bootstrap/pull/4),
boot.py was changed to use that file, and now step 3 gets rid of the
individual PXE node conf files.
