### PR TITLE
Get rid of pxe and pxe_name host variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,11 @@ The tests we run are in here: https://github.com/CSC-IT-Center-for-Science/ansib
 They generate a hosts file that looks like this:
 
 <pre>
-10.1.1.4 io io.int.fgci.csc.fi
 10.1.100.1 io1 io1.int.fgci.csc.fi
 10.2.100.1 io1-ib io1-ib.int.fgci.csc.fi
-10.1.1.6 io-admin io-admin.int.fgci.csc.fi
-10.1.100.1 io-grid io-grid.int.fgci.csc.fi
-10.1.100.1 io-install io-install.int.fgci.csc.fi
+10.1.1.6 io-admin io-admin io-admin.int.fgci.csc.fi io-admin.int.fgci.csc.fi
+10.1.1.7 io-grid io-grid io-grid.int.fgci.csc.fi io-grid.int.fgci.csc.fi
+10.1.1.8 io-install io-install io-install.int.fgci.csc.fi io-install.int.fgci.csc.fi
 </pre>
 
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Configures PXE
 Requirements
 ------------
 
-a hosts file that looks like this (please note that node1/node2 below are not used to populate the hosts file, only the pxe_name and int_ip_addr and ib_ip_addr):
+a hosts file that looks like this:
 
 <pre>
 
 [compute]
-node1 int_ip_addr=10.1.2.1 ib_ip_addr=10.2.2.1 mac_address=00:11:22:33:44:55 pxe=yes pxe_name=io1
-node2 int_ip_addr=10.1.2.2 ib_ip_addr=10.2.2.2 mac_address=00:11:22:33:44:56 pxe=yes pxe_name=io2
+node1 int_ip_addr=10.1.2.1 ib_ip_addr=10.2.2.1 mac_address=00:11:22:33:44:55
+node2 int_ip_addr=10.1.2.2 ib_ip_addr=10.2.2.2 mac_address=00:11:22:33:44:56
 
 [pxe_bootable_nodes:children]
 compute
@@ -77,11 +77,12 @@ The tests we run are in here: https://github.com/CSC-IT-Center-for-Science/ansib
 They generate a hosts file that looks like this:
 
 <pre>
+10.1.1.4 io io.int.fgci.csc.fi
 10.1.100.1 io1 io1.int.fgci.csc.fi
 10.2.100.1 io1-ib io1-ib.int.fgci.csc.fi
-10.1.1.6 io-admin admin-node io-admin.int.fgci.csc.fi
-10.1.100.1 io-grid localhost io-grid.int.fgci.csc.fi
-10.1.100.1 io-install localhost io-install.int.fgci.csc.fi
+10.1.1.6 io-admin io-admin.int.fgci.csc.fi
+10.1.100.1 io-grid io-grid.int.fgci.csc.fi
+10.1.100.1 io-install io-install.int.fgci.csc.fi
 </pre>
 
 

--- a/templates/dhcp_node.conf
+++ b/templates/dhcp_node.conf
@@ -1,6 +1,5 @@
 # Hosts
 {% for item in groups['pxe_bootable_nodes'] %}
-{% if hostvars[item]['pxe_name'] %}
 host {{ item }} {
   hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['int_ip_addr'] }};
@@ -40,5 +39,4 @@ host {{ item }} {
     filename "undionly.kpxe";
   }
 }
-{% endif %}
 {% endfor %}

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -2,9 +2,9 @@
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
 {% for item in hosts_file_pxe_group_to_populate %}
-{{ hostvars[item].int_ip_addr }} {{ hostvars[item].pxe_name }} {{ hostvars[item].pxe_name }}.{{ intDomain }}.{{ siteDomain }}
+{{ hostvars[item].int_ip_addr }} {{ item }} {{ item }}.{{ intDomain }}.{{ siteDomain }}
 {% if hostvars[item].ib_ip_addr is defined %}
-{{ hostvars[item].ib_ip_addr }} {{ hostvars[item].pxe_name }}-ib {{ hostvars[item].pxe_name }}-ib.{{ intDomain }}.{{ siteDomain }}
+{{ hostvars[item].ib_ip_addr }} {{ item }}-ib {{ item }}-ib.{{ intDomain }}.{{ siteDomain }}
 {% endif %}
 {% endfor %}
 
@@ -23,6 +23,6 @@
 {% for item in hosts_file_login_group_to_populate %}
 {{ hostvars[item].int_ip_addr }} {{ siteName }} {{item}} {{ siteName }}.{{ intDomain }}.{{ siteDomain }} {{ item }}.{{ intDomain }}.{{ siteDomain }}
 {% if hostvars[item].ib_ip_addr is defined %}
-{{ hostvars[item].ib_ip_addr }} {{ hostvars[item].pxe_name }}-ib {{ hostvars[item].pxe_name }}-ib.{{ intDomain }}.{{ siteDomain }}
+{{ hostvars[item].ib_ip_addr }} {{ item }}-ib {{ item }}-ib.{{ intDomain }}.{{ siteDomain }}
 {% endif %}
 {% endfor %}

--- a/tests/inventory
+++ b/tests/inventory
@@ -11,10 +11,10 @@ io-admin int_ip_addr=10.1.1.6 mac_address=00:11:22:33:44:58 ib_ip_addr=10.2.100.
 io-nfs int_ip_addr=10.1.1.5 mac_address=00:11:22:33:44:57 ib_ip_addr=10.2.100.22
 
 [grid]
-localhost
+io-grid int_ip_addr=10.1.1.7
 
 [install]
-localhost
+io-install int_ip_addr=10.1.1.8
 
 [compute]
 io1 int_ip_addr=10.1.100.1 mac_address=00:11:22:33:44:55 ib_ip_addr=10.2.100.1 kickstart_profile="FGCI-compute-node" kickstart_server_ip="10.1.1.2" internal_interface="eth0" kickstart_partitions="autopart --type=lvm" kickstart_packages="git" ansible_pull_kickstart=True

--- a/tests/inventory
+++ b/tests/inventory
@@ -2,13 +2,13 @@
 localhost
 
 [login]
-localhost4 ext_ip_addr=192.168.1.1 int_ip_addr=10.1.1.4 mac_address=00:11:22:33:44:56 pxe_name=io ib_ip_addr=10.2.100.44
+io ext_ip_addr=192.168.1.1 int_ip_addr=10.1.1.4 mac_address=00:11:22:33:44:56 ib_ip_addr=10.2.100.44
 
 [admin]
-admin-node int_ip_addr=10.1.1.6 mac_address=00:11:22:33:44:58 pxe_name=io-admin ib_ip_addr=10.2.100.33
+io-admin int_ip_addr=10.1.1.6 mac_address=00:11:22:33:44:58 ib_ip_addr=10.2.100.33
 
 [nfs]
-localhost6 int_ip_addr=10.1.1.5 mac_address=00:11:22:33:44:57 pxe_name=io-nfs ib_ip_addr=10.2.100.22
+io-nfs int_ip_addr=10.1.1.5 mac_address=00:11:22:33:44:57 ib_ip_addr=10.2.100.22
 
 [grid]
 localhost
@@ -17,7 +17,7 @@ localhost
 localhost
 
 [compute]
-localhost int_ip_addr=10.1.100.1 mac_address=00:11:22:33:44:55 pxe_name=io1 ib_ip_addr=10.2.100.1 kickstart_profile="FGCI-compute-node" kickstart_server_ip="10.1.1.2" internal_interface="eth0" kickstart_partitions="autopart --type=lvm" kickstart_packages="git" ansible_pull_kickstart=True
+io1 int_ip_addr=10.1.100.1 mac_address=00:11:22:33:44:55 ib_ip_addr=10.2.100.1 kickstart_profile="FGCI-compute-node" kickstart_server_ip="10.1.1.2" internal_interface="eth0" kickstart_partitions="autopart --type=lvm" kickstart_packages="git" ansible_pull_kickstart=True
 
 [pxe_bootable_nodes:children]
 compute


### PR DESCRIPTION
The item name in the ansible inventory already specifies the hostname,
using a different hostname via the pxe_name is just extra complexity
for no benefit.
