### PR TITLE
Simplify PXE chainloading/booting

### DIFF
--- a/templates/dhcp_node.conf
+++ b/templates/dhcp_node.conf
@@ -11,7 +11,7 @@ host {{ item }} {
   }
   elsif option arch = 00:07 {
     # EFI 64-bit
-    filename "ipxe-x64.efi";
+    filename "ipxe.efi";
   } elsif option arch = 00:00 {
     # Legacy x86 BIOS
     filename "undionly.kpxe";

--- a/templates/dhcp_node.conf
+++ b/templates/dhcp_node.conf
@@ -5,38 +5,19 @@ host {{ item }} {
   fixed-address {{  hostvars[item]['int_ip_addr'] }};
   send host-name "{{ item }}.{{ dhcp_common_domain }}";
 
-  if exists ipxe.http or exists ipxe.efi {
-      filename "http://{{ dhcp_tftp_server_ip }}/cgi-bin/boot.py";
-  }
-  elsif exists user-class and option user-class = "iPXE" {
-    # We're already using iPXE, but not a feature-full version,
-    # and possibly an out-of-date version from ROM, so load a more
-    # complete version with native drivers
-    # Allow both legacy BIOS and EFI architectures
-    if option arch = 00:07 {
-        filename "ipxe-x64.efi";
-    } elsif option arch = 00:00 {
-        filename "undionly.kpxe";
-    }
-  }
-  elsif exists user-class and option user-class = "gPXE" {
-    # If someone has an old version of gPXE burned into their ROM,
-    # load a more recent iPXE
-    filename "undionly.kpxe";
+  if exists user-class and (option user-class = "iPXE"
+     or option user-class = "gPXE") {
+    filename "http://{{ dhcp_tftp_server_ip }}/cgi-bin/boot.py";
   }
   elsif option arch = 00:07 {
     # EFI 64-bit
-    # I like to use iPXE-provided drivers, so therefore give ipxe.efi
-    # to all non-iPXE clients, use snponly.efi if you have unsupported
-    # or misbehaving NICs
     filename "ipxe-x64.efi";
-  }
-  elsif option arch = 00:00 {
-    # Legacy BIOS x86 mode
-    # I like to use iPXE-provided drivers, so therefore give ipxe.pxe
-    # to all non-iPXE clients, use undionly.kpxe if you have unsupported
-    # or misbehaving NICs
+  } elsif option arch = 00:00 {
+    # Legacy x86 BIOS
     filename "undionly.kpxe";
+  } else {
+    # Last resort
+    filename "ipxe.pxe";
   }
 }
 {% endfor %}


### PR DESCRIPTION
Since we're not doing anything fancy, assume that if iPXE or gPXE exists they can successfully boot via HTTP. That might be slightly less risky than unnecessarily chainloading iPXE which might not work on some NIC's. Also, as a last resort, try the ipxe.pxe image.
