### PR TITLE
Don't wait randomly in rc.local running ansible-pull-script

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -106,7 +106,7 @@ if [ $? == 0 ]; then
 # ansible-pull anyway can't run in the chroot during kickstart
 /usr/bin/ansible -m cron -a "name='ansible-pull' user=root job='/bin/bash /usr/local/bin/ansible-pull-script.sh >/var/log/ansible-pull.ks.log 2>&1' minute="*/15" cron_file=ansible-pull" localhost
 chmod +x /etc/rc.local
-echo '/bin/bash /usr/local/bin/ansible-pull-script.sh >/var/log/ansible.boot.log 2>&1' >>/etc/rc.local
+echo '/bin/bash /usr/local/bin/ansible-pull-script.sh -n >/var/log/ansible.boot.log 2>&1' >>/etc/rc.local
 else
 echo "could not get /usr/local/bin/ansible-pull-script.sh from http://{{ kickstart_server_ip }}/ansible-pull-script.sh"
 fi


### PR DESCRIPTION
Otherwise it waits for a random time, causing systemd to give up waiting for rc.local to finish.
