### PR TITLE
Remove old style kickstart generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ hosts_file_login_group_to_populate: ""
 hosts_file_extra_group_to_populate: ""
 </pre>
 
-Using a custom inventory script to only write kickstart templates once per child group of a group by:
+Using the custom inventory script to only write kickstart templates once per child group of a group by:
 
 <pre>
-hosts_file_use_custom_inventory: True
 hosts_file_group_to_populate: "pxe_bootable_nodes"
 hosts_file_inventory_location: "hosts"
 </pre>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,6 @@ hosts_file_login_group_to_populate: "{{ groups.login }}"
 hosts_file_extra_group_to_populate: ""
 
 #hosts_file_inventory_location points to where the ansible inventory file is
-hosts_file_use_custom_inventory: False
 hosts_file_group_to_populate: "pxe_bootable_nodes"
 hosts_file_inventory_location: "hosts"
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -53,14 +53,7 @@
 - name: print each host
   debug: var=item verbosity=1
   with_items: "{{ hosts_file_my_group }}"
-  when: hosts_file_use_custom_inventory
 
-- name: copy over kickstart file (new and faster style)
+- name: copy over kickstart file
   template: src="kickstart.cfg" dest="{{ ksBootSrvDir }}/{{ hostvars[item].kickstart_profile }}" owner=apache group=apache mode=0644
   with_items: "{{ hosts_file_my_group }}"
-  when: hosts_file_use_custom_inventory
-
-- name: copy over kickstart file (old style)
-  template: src="kickstart.cfg" dest="{{ ksBootSrvDir }}/{{ hostvars[item].kickstart_profile }}" owner=apache group=apache mode=0644
-  with_items: "{{ groups.pxe_bootable_nodes }}"
-  when: hosts_file_use_custom_inventory == False

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,7 +13,6 @@
      - rootpwhash: "SHAFOOO"
      - hosts_file_login_group_to_populate: ""
      - hosts_file_inventory_location: "/ansible-role-pxe_config/tests/inventory"
-     - hosts_file_use_custom_inventory: True
      - hosts_file_extra_group_to_populate: "{{ groups.switches }}"
    pre_tasks:
    - name: touch hosts_file_to_populate


### PR DESCRIPTION
Even if hosts_file_use_custom_inventory == True, skipping over all the
hosts in the old-style kickstart generation takes a long time. In our
environment, running

ansible-playbook install.yml --tags=pxe

shows the following timings:
# Wednesday 14 September 2016  10:10:12 +0300 (0:00:01.322)       0:02:16.558 ***

ansible-role-pxe_config : copy over kickstart file (old style) --------- 34.82s
ansible-role-pxe_config : populate hosts file from template with PXE hosts -- 20.68s
ansible-role-pxe_config : create pxe boot data json file --------------- 19.28s
ansible-role-pxe_config : create_dhcp_configs -------------------------- 19.10s
ansible-role-pxe_config : copy over kickstart file (new and faster style) --- 9.45s

(top 5 only, all other tasks are below 2s.)
