### PR TITLE
Simplify PXE boot image selection

### DIFF
--- a/templates/dhcp_node.conf
+++ b/templates/dhcp_node.conf
@@ -9,16 +9,12 @@ host {{ item }} {
   if exists user-class and (option user-class = "iPXE"
      or option user-class = "gPXE") {
     filename "http://{{ dhcp_tftp_server_ip }}/cgi-bin/boot.py";
-  }
-  elsif option arch = 00:07 {
-    # EFI 64-bit
-    filename "ipxe.efi";
   } elsif option arch = 00:00 {
     # Legacy x86 BIOS
     filename "undionly.kpxe";
   } else {
-    # Last resort
-    filename "ipxe.pxe";
+    # UEFI 64-bit
+    filename "ipxe.efi";
   }
 }
 {% endfor %}


### PR DESCRIPTION
Simplify, such that if arch=0 then use x86 BIOS image, else use the
64-bit UEFI image.