### PR TITLE
Install ansible in kickstart %post section

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -84,6 +84,7 @@ openssh-clients
 
 /usr/bin/yum clean all
 /usr/bin/yum update -y --skip-broken
+/usr/bin/yum -y -q install ansible
 
 /usr/bin/mkdir /root/.ssh && /usr/bin/chmod 700 /root/.ssh
 {% if root_keys is defined %}


### PR DESCRIPTION
CentOS 7.4 moved ansible from the EPEL repo to the CentOS extras repo.
For some reason it doesn't work to enable extras as a repo in
kickstart, thus install it afterwards in the %post section, when the
standard CentOS repos, including extras, have been setup.

To make this work one also needs to remove ansible from the
kickstart_packages lists in group_vars.