### PR TITLE
Use snponly.efi instead of ipxe.efi for UEFI boot

### DIFF
--- a/templates/dhcp_node.conf
+++ b/templates/dhcp_node.conf
@@ -14,7 +14,7 @@ host {{ item }} {
     filename "undionly.kpxe";
   } else {
     # UEFI 64-bit
-    filename "ipxe.efi";
+    filename "snponly.efi";
   }
 }
 {% endfor %}


### PR DESCRIPTION
ipxe.efi uses iPXE network card drivers; at least Dell PowerEdge
Haswell NIC's don't work correctly with it. snponly.efi is the UEFI
equivalent of undionly.kpxe for legacy BIOS, and uses the builtin NIC
driver. Which seems to work.